### PR TITLE
fix format() jsDoc

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,8 +95,9 @@ function extract(npmignore) {
 module.exports.extract = extract;
 
 /**
- * Normalize newlines and split the string
- * into an array.
+ * Rebuild array back into newline delimited,
+ * merging .gitignore, .npmignore extras &
+ * comments (expcted output).
  *
  * @param  {String} `str`
  * @return {Array}


### PR DESCRIPTION
Seems like you forgot to edit after copy/paste from [split()](https://github.com/jonschlinkert/npmignore/blob/e9b917100330682d373fbb5074cfbad64022d73c/index.js#L123).
