### PR TITLE
Add command-line option to keep existing .npmignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ _If you want to preserve everything in your `.npmignore` file, regardless of wha
  - `-d`|`--dest`: optionally define a different destination filepath. Good for test driving to see what will be generated in advance.
  - `-g`|`--gitignore`: alternate source filepath for `.gitignore`.
  - `-n`|`--npmignore`: alternate source filepath for `.npmignore`.
+ - `-k`|`--keepdest`: avoids altering the destination file
 
 ## API
 
@@ -77,7 +78,7 @@ npmignore(npm, git, options);
  - `options` {Object}
     + `ignore` Array of patterns to add to the existing patterns from `.gitignore`
     + `unignore` Array of patterns to remove from `.npmignore`. This will not un-ignore patterns in `.gitignore`
-
+    + `keepdest` if `true`, avoids altering the destination file
 
 ## Run tests
 Install dev dependencies.

--- a/cli.js
+++ b/cli.js
@@ -20,6 +20,9 @@ var npmignore = argv.n || argv.npmignore || '.npmignore';
 // optionally specify a different destination
 var dest = argv.d || argv.dest || npmignore;
 
+// whether to keep destination file intact
+var keepdest = argv.k || argv.keepdest || false;
+
 // patterns to ignore
 var i = argv.i || argv.ignore;
 
@@ -35,7 +38,7 @@ var npm = read(npmignore);
 // Parse the files and create a new `.npmignore` file
 // based on the given arguments along with data that
 // is already present in either or both files.
-var res = parser(npm, git, {ignore: i, unignore: u});
+var res = parser(npm, git, {ignore: i, unignore: u, keepdest: keepdest});
 
 // write the file.
 fs.writeFileSync(dest, res);

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ module.exports = function npmignore(npm, git, options) {
 
   // get the relevant lines from `.npmignore`
   if (typeof npm === 'string') {
-    npm = extract(npm);
+    npm = extract(npm, {npmignored: options.keepdest});
   }
 
   if (options.unignore) {
@@ -60,12 +60,17 @@ module.exports = function npmignore(npm, git, options) {
  * @return {Array} Array of lines
  */
 
-function extract(npmignore) {
+function extract(npmignore, options) {
   if (npmignore == null) {
     throw new Error('npmignore expects a string.');
   }
 
   var lines = split(npmignore);
+
+  if (options.npmignored) {
+	  return lines;
+  }
+
   var len = lines.length;
   var npmignored = false;
   var git = [];
@@ -74,7 +79,7 @@ function extract(npmignore) {
 
   while (i < len) {
     var line = lines[i++];
-    if (re.test(line)) {
+    if (!npmignored && re.test(line)) {
       npmignored = true;
     }
 


### PR DESCRIPTION
Instead of adding `# npmignore` line in `.npmignore`, pass `-k` or `--keepdest`
