### PR TITLE
Some improvements

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -14,8 +14,8 @@ log.runner = 'npmignore';
  * Find the local `ignore` files we need
  */
 
-var gitignore = argv.g || '.gitignore';
-var npmignore = argv.n || '.npmignore';
+var gitignore = argv.g || argv.gitignore || '.gitignore';
+var npmignore = argv.n || argv.npmignore || '.npmignore';
 
 // optionally specify a different destination
 var dest = argv.d || argv.dest || npmignore;

--- a/cli.js
+++ b/cli.js
@@ -45,6 +45,9 @@ log.inform('updated', dest);
 log.success('  Done.');
 
 function read(fp) {
+  if (fp.indexOf(',') > -1) {
+    return fp.split(/,/g).map(read).join('\n');
+  }
   fp = path.join(process.cwd(), fp);
   if (!fs.existsSync(fp)) {
     return null;

--- a/cli.js
+++ b/cli.js
@@ -48,7 +48,9 @@ function read(fp) {
   if (fp.indexOf(',') > -1) {
     return fp.split(/,/g).map(read).join('\n');
   }
-  fp = path.join(process.cwd(), fp);
+  if (!path.isAbsolute(fp)) {
+    fp = path.join(process.cwd(), fp);
+  }
   if (!fs.existsSync(fp)) {
     return null;
   }

--- a/cli.js
+++ b/cli.js
@@ -54,5 +54,5 @@ function read(fp) {
   if (!fs.existsSync(fp)) {
     return null;
   }
-  return fs.readFileSync(fp, 'utf8');
+  return '# Rules from: ' + fp + '\n' + fs.readFileSync(fp, 'utf8');
 }


### PR DESCRIPTION
- Add missing `--gitignore` `--npmignore` argument keys
- Allow multiple comma separated .gitignore/.npmignore files
  
  Now you can do:
  
  ```
  npmignore -g .gitignore,~/.gitognore
  ```
  
  Fixes #1?
- Allow absolute paths
  
  ```
  npmignore -g ~/.gitognore
  ```
- Adds name of the file from which the rules were copied
  
  Like
  
  ```
  # Rules from ~/.gitignore
  ...
  
  # Rules from some/other/.npmignore
  ...
  ```
  
  Useful now that multiple ignore files can be used
